### PR TITLE
Fix path order & better error reporting

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -7,6 +7,7 @@ Merge with [rework-inline](https://www.npmjs.org/package/rework-inline) bring th
 * Use [find-file](https://www.npmjs.org/package/find-file) to lookup imports
 * Automated tests
 * relative `@import`
+* better error reporting
 
 # 0.0.3 / 2013-08-07
 

--- a/test/fixtures/qux.css
+++ b/test/fixtures/qux.css
@@ -1,0 +1,3 @@
+quux {
+  not: "relative/qux";
+}


### PR DESCRIPTION
This commit include the followings:
- when we include a file, latest added path is looked first
- better error reporting (source info when available + path where we
  are using to find files)
