### PR TITLE
Create meaningful exception for: Cannot read property 'path' of undefined

### DIFF
--- a/index.js
+++ b/index.js
@@ -67,6 +67,29 @@ function createError(file, src, paths) {
 }
 
 /**
+ * Create bad import rule error
+ *
+ * @param {String} rule
+ * @api private
+ */
+
+function createImportError(rule) {
+	var url = rule.import ? rule.import.replace(/\r?\n/g, ' ') : '<no url>';
+	var err = ['Bad import url: @import ' + url];
+
+	if (rule.position) {
+		err.push('  starting at line ' + rule.position.start.line + ' column ' + rule.position.start.column);
+		err.push('    ending at line ' + rule.position.end.line + ' column ' + rule.position.end.column);
+
+		if (rule.position.source) {
+			err.push('  in ' + rule.position.source);
+		}
+	}
+
+	return err.join('\n');
+ }
+
+/**
  * Check if a file exists
  *
  * @param {String} file
@@ -126,6 +149,10 @@ function run(style, opts) {
 		var importRule = '@import ' + rule.import + ';';
 		var data = parse(importRule)[0];
 		var pos = rule.position ? rule.position.source : null;
+
+		if (!data) {
+			throw Error(createImportError(rule));
+		}
 
 		if (urlRegex({ exact: true }).test(data.path)) {
 			ret.push(rule);

--- a/index.js
+++ b/index.js
@@ -74,7 +74,7 @@ function createError(file, src, paths) {
  */
 
 function createImportError(rule) {
-	var url = rule.import ? rule.import.replace(/\r?\n/g, ' ') : '<no url>';
+	var url = rule.import ? rule.import.replace(/\r?\n/g, '\\n') : '<no url>';
 	var err = ['Bad import url: @import ' + url];
 
 	if (rule.position) {


### PR DESCRIPTION
If the `@import url;` rule cannot be parsed by `parse-import` [here](https://github.com/reworkcss/rework-import/blob/master/index.js#L127) then `data` is undefined.  From what I can see this is mainly when there is a missing semi or a bad `url` which causes problems in down the line references to `data.path`.

This PR helps to make a more meaningful error out of that.

@kevva, I'm not that active here so if this is good by you please merge :)