### PR TITLE
Include external

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,5 @@
+sudo: false
 language: node_js
 node_js:
   - '0.10'
+  - '0.12'

--- a/README.md
+++ b/README.md
@@ -47,6 +47,13 @@ Type: `Function`
 
 A function to transform the content of imported files. Takes one argument and should return the modified content. Useful if you use [`css-whitespace`](https://github.com/reworkcss/css-whitespace).
 
+### includeExternal
+
+Type: `boolean`
+Default: `false`
+
+Use this to inline imports fetched via URLs.
+
 ## Example
 
 ```css

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "css": "^2.0.0",
     "globby": "^2.0.0",
     "parse-import": "^2.0.0",
+    "sync-request": "^2.0.1",
     "url-regex": "^3.0.0"
   },
   "devDependencies": {

--- a/test/fixtures/simple/external.css
+++ b/test/fixtures/simple/external.css
@@ -1,0 +1,28 @@
+
+@font-face {
+  font-family: 'Roboto Slab';
+  font-style: normal;
+  font-weight: 400;
+  src: local('Roboto Slab Regular'), local('RobotoSlab-Regular'), url(http://fonts.gstatic.com/s/robotoslab/v6/y7lebkjgREBJK96VQi37Zp0EAVxt0G0biEntp43Qt6E.ttf) format('truetype');
+}
+
+@font-face {
+  font-family: 'Roboto Slab';
+  font-style: normal;
+  font-weight: 700;
+  src: local('Roboto Slab Bold'), local('RobotoSlab-Bold'), url(http://fonts.gstatic.com/s/robotoslab/v6/dazS1PrQQuCxC3iOAJFEJZ_TkvowlIOtbR7ePgFOpF4.ttf) format('truetype');
+}
+
+@media (min-width: 25em) {
+  body {
+    background: red;
+  }
+
+  h1 {
+    color: grey;
+  }
+}
+
+body {
+  background: black;
+}

--- a/test/test.js
+++ b/test/test.js
@@ -7,9 +7,14 @@ var test = require('ava');
 var importer = require('../');
 var fixture = path.join.bind(null, __dirname, 'fixtures');
 
+var loadFixture = function(str) {
+	var file = read(fixture(str), 'utf8')
+	return file.trim().replace(/\r/g, "" )
+}
+
 test('import stylesheet', function (t) {
-	var src = read(fixture('simple/index.css'), 'utf8');
-	var expected = read(fixture('simple/expected.css'), 'utf8').trim();
+	var src = loadFixture('simple/index.css');
+	var expected = loadFixture('simple/expected.css');
 	var css = rework(src)
 		.use(importer({path: fixture('simple')}))
 		.toString();
@@ -19,8 +24,8 @@ test('import stylesheet', function (t) {
 });
 
 test('import stylesheets recursively', function (t) {
-	var src = read(fixture('recursive/index.css'), 'utf8');
-	var expected = read(fixture('recursive/expected.css'), 'utf8').trim();
+	var src = loadFixture('recursive/index.css');
+	var expected = loadFixture('recursive/expected.css');
 	var css = rework(src)
 		.use(importer({path: fixture('recursive')}))
 		.toString();
@@ -30,8 +35,8 @@ test('import stylesheets recursively', function (t) {
 });
 
 test('import stylesheets relatively', function (t) {
-	var src = read(fixture('relative/index.css'), 'utf8');
-	var expected = read(fixture('relative/expected.css'), 'utf8').trim();
+	var src = loadFixture('relative/index.css');
+	var expected = loadFixture('relative/expected.css');
 	var css = rework(src)
 		.use(importer({path: fixture('relative')}))
 		.toString();
@@ -41,8 +46,8 @@ test('import stylesheets relatively', function (t) {
 });
 
 test('import stylesheets with custom transform', function (t) {
-	var src = read(fixture('transform/index.css'), 'utf8');
-	var expected = read(fixture('transform/expected.css'), 'utf8').trim();
+	var src = loadFixture('transform/index.css');
+	var expected = loadFixture('transform/expected.css');
 	var css = rework(src)
 		.use(importer({
 			path: fixture('transform'),
@@ -55,8 +60,8 @@ test('import stylesheets with custom transform', function (t) {
 });
 
 test('import stylesheet with long media query', function (t) {
-	var src = read(fixture('media-query/index.css'), 'utf8');
-	var expected = read(fixture('media-query/expected.css'), 'utf8').trim();
+	var src = loadFixture('media-query/index.css');
+	var expected = loadFixture('media-query/expected.css');
 	var css = rework(src)
 		.use(importer({path: fixture('media-query')}))
 		.toString();
@@ -66,8 +71,8 @@ test('import stylesheet with long media query', function (t) {
 });
 
 test('import stylesheets without `path` option', function (t) {
-	var src = read(fixture('cwd/index.css'), 'utf8');
-	var expected = read(fixture('cwd/expected.css'), 'utf8').trim();
+	var src = loadFixture('cwd/index.css');
+	var expected = loadFixture('cwd/expected.css');
 	var css = rework(src)
 		.use(importer())
 		.toString();
@@ -77,8 +82,8 @@ test('import stylesheets without `path` option', function (t) {
 });
 
 test('import stylesheets with `path` passed to rework', function (t) {
-	var src = read(fixture('simple/index.css'), 'utf8');
-	var expected = read(fixture('simple/expected.css'), 'utf8').trim();
+	var src = loadFixture('simple/index.css');
+	var expected = loadFixture('simple/expected.css');
 	var css = rework(src, {source: fixture('simple/index.css')})
 		.use(importer())
 		.toString();
@@ -88,7 +93,7 @@ test('import stylesheets with `path` passed to rework', function (t) {
 });
 
 test('show readable trace on import error', function (t) {
-	var src = read(fixture('missing/index.css'), 'utf8');
+	var src = loadFixture('missing/index.css');
 	var msg = [
 		'Failed to find foo.css in [',
 		'    ' + fixture('missing'),
@@ -107,7 +112,7 @@ test('show readable trace on import error', function (t) {
 });
 
 test('import stylesheets with sourcemap', function (t) {
-	var src = read(fixture('sourcemap/index.css'), 'utf8');
+	var src = loadFixture('sourcemap/index.css');
 	var css = rework(src, {source: fixture('sourcemap/index.css')})
 		.use(importer())
 		.toString({
@@ -115,7 +120,7 @@ test('import stylesheets with sourcemap', function (t) {
 			sourcemapAsObject: true
 		});
 
-	t.assert(css.map.sources[0] === fixture('sourcemap/foo.css'));
-	t.assert(css.map.sources[1] === fixture('sourcemap/index.css'));
+	t.assert(path.resolve(css.map.sources[0]) === fixture('sourcemap/foo.css'), "1st differes");
+	t.assert(path.resolve(css.map.sources[1]) === fixture('sourcemap/index.css'), "2nd differs");
 	t.end();
 });

--- a/test/test.js
+++ b/test/test.js
@@ -7,10 +7,30 @@ var test = require('ava');
 var importer = require('../');
 var fixture = path.join.bind(null, __dirname, 'fixtures');
 
+process.on('uncaughtException', function(err) {
+  console.error(err.stack);
+});
+
 var loadFixture = function(str) {
 	var file = read(fixture(str), 'utf8')
 	return file.trim().replace(/\r/g, "" )
 }
+
+
+test('import stylesheet including external stuff', function (t) {
+	var src = loadFixture('simple/index.css');
+	//This test is brittle since it fetches data from google.
+	var expected = loadFixture('simple/external.css');
+	var css = rework(src)
+		.use(importer({path: fixture('simple'), includeExternal : true }))
+		.toString();
+
+	console.log("Actual\n");
+	console.log(css);
+
+	t.assert(css === expected);
+	t.end();
+});
 
 test('import stylesheet', function (t) {
 	var src = loadFixture('simple/index.css');


### PR DESCRIPTION
Add functionality to include @imports from external URLs. I need this to tightening up CSP logic, and to bundle stand-alone apps that don't have internet connections.
